### PR TITLE
Fix shader constants and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,4 @@ npm run dev
 npm run build
 npm run test
 npm run lint
+```

--- a/src/gpu/buffers.ts
+++ b/src/gpu/buffers.ts
@@ -7,7 +7,8 @@ import {
   MAX_AGENTS,
   WORKGROUP_SIZE,
   ENV_TEXTURE_SIZE,
-  GPU_STATS_BUFFER_SIZE
+  GPU_STATS_BUFFER_SIZE,
+  MAX_AGE
 } from '../config';
 
 export async function initGPU() {
@@ -94,7 +95,7 @@ export async function initGPU() {
   // Shader modules
   const computeModule = device.createShaderModule({
     code: computeSrc,
-    constants: { MAX_AGENTS, WORKGROUP_SIZE }
+    constants: { MAX_AGENTS, WORKGROUP_SIZE, MAX_AGE }
   });
   const plumeModule = device.createShaderModule({
     code: plumeSrc,


### PR DESCRIPTION
## Summary
- close the README code fence
- pass `MAX_AGE` constant to the compute shader

## Testing
- `npx tsc --noEmit`
- `npm run test` *(fails: waiting for file changes)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6889ec0e2d8883238d77917e22de1755