### PR TITLE
Fix buffer usage flags and async GPU reads

### DIFF
--- a/src/audio/sound.ts
+++ b/src/audio/sound.ts
@@ -9,6 +9,7 @@ export function initAudio() {
 }
 
 export function updateAudio(audio: any, biomass: number) {
+  if (!Number.isFinite(biomass)) return;
   const rel = biomass / 1_000_000;
   audio.osc.frequency.value = 110 * Math.pow(2, 8 * rel);
   audio.gain.gain.value = 0.8 / (1 + Math.exp(-12 * (rel - 0.5)));

--- a/src/dev/devpanel.ts
+++ b/src/dev/devpanel.ts
@@ -3,11 +3,15 @@ export function initDevPanel(device: GPUDevice, querySet: GPUQuerySet) {
     size: 16,
     usage:
       GPUBufferUsage.COPY_DST |
-      GPUBufferUsage.MAP_READ
+      GPUBufferUsage.MAP_READ |
+      GPUBufferUsage.QUERY_RESOLVE
   });
 
+  let pending = false;
   return {
     async collect() {
+      if (pending) return Promise.resolve({});
+      pending = true;
       const enc = device.createCommandEncoder();
       enc.resolveQuerySet(querySet, 0, 2, resolveBuffer, 0);
       device.queue.submit([enc.finish()]);
@@ -16,6 +20,7 @@ export function initDevPanel(device: GPUDevice, querySet: GPUQuerySet) {
         resolveBuffer.getMappedRange()
       );
       resolveBuffer.unmap();
+      pending = false;
       const diff = Number(data[1] - data[0]) * 1e-6;
       return { frameTime: diff };
     }

--- a/src/gpu/buffers.ts
+++ b/src/gpu/buffers.ts
@@ -54,13 +54,16 @@ export async function initGPU() {
   // Genome buffer
   const genomes = device.createBuffer({
     size: MAX_AGENTS * 48,
-    usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST
+    usage:
+      GPUBufferUsage.STORAGE |
+      GPUBufferUsage.COPY_DST |
+      GPUBufferUsage.COPY_SRC
   });
 
   // Free-list buffers
   const freeList = device.createBuffer({
     size: 8,
-    usage: GPUBufferUsage.STORAGE
+    usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST
   });
   const freeIds = device.createBuffer({
     size: MAX_AGENTS * 4,

--- a/src/storage/persistence.ts
+++ b/src/storage/persistence.ts
@@ -14,7 +14,10 @@ export function initPersistence(
     usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
   });
 
+  let saving = false;
   async function autoSave() {
+    if (saving) return;
+    saving = true;
     const enc = device.createCommandEncoder();
     enc.copyBufferToBuffer(genomeBuffer, 0, readback, 0, genomeSize);
     device.queue.submit([enc.finish()]);
@@ -31,6 +34,7 @@ export function initPersistence(
     };
     localStorage.setItem('evo-save', btoa(JSON.stringify(saveData)));
     readback.unmap();
+    saving = false;
   }
 
   async function load(str: string) {


### PR DESCRIPTION
## Summary
- correct buffer usage flags for genomes and freelist
- prevent overlapping reads when collecting GPU stats
- throttle persistence autosave to avoid buffer mapping conflicts
- guard audio update against invalid numbers

## Testing
- `npx vitest run`
- `npx playwright test` *(fails: Cannot find package '@playwright/test')*


------
https://chatgpt.com/codex/tasks/task_e_688a0057628083239ea9a230e2de21c4