### PR TITLE
Fix WGSL compatibility and storage error handling

### DIFF
--- a/src/gpu/shaders/compute.wgsl
+++ b/src/gpu/shaders/compute.wgsl
@@ -1,8 +1,8 @@
 // src/gpu/shaders/compute.wgsl
-@id(0) override MAX_AGENTS: u32;
-@id(1) override WORKGROUP_SIZE: u32;
-@id(2) override ENV_TEXTURE_SIZE: u32;
-@id(3) override MAX_AGE: f32;
+override MAX_AGENTS: u32;
+override WORKGROUP_SIZE: u32;
+override ENV_TEXTURE_SIZE: u32;
+override MAX_AGE: f32;
 
 struct AgentState {
   pos: vec2<f32>;

--- a/src/gpu/shaders/plume.wgsl
+++ b/src/gpu/shaders/plume.wgsl
@@ -1,5 +1,5 @@
 // src/gpu/shaders/plume.wgsl
-@id(0) override ENV_TEXTURE_SIZE: u32;
+override ENV_TEXTURE_SIZE: u32;
 
 struct PlumeParams {
   seed: u32;

--- a/src/gpu/shaders/stats.wgsl
+++ b/src/gpu/shaders/stats.wgsl
@@ -1,6 +1,6 @@
 // src/gpu/shaders/stats.wgsl
-@id(0) override MAX_AGENTS: u32;
-@id(1) override MAX_AGE: f32;
+override MAX_AGENTS: u32;
+override MAX_AGE: f32;
 
 struct AgentState {
   pos: vec2<f32>;

--- a/src/storage/persistence.ts
+++ b/src/storage/persistence.ts
@@ -41,7 +41,11 @@ export function initPersistence(
       envSeed: 0,
       rngSeed: getFrameHash()
     };
-    localStorage.setItem('evo-save', btoa(JSON.stringify(saveData)));
+    try {
+      localStorage.setItem('evo-save', btoa(JSON.stringify(saveData)));
+    } catch (e) {
+      console.warn('Auto-save failed', e);
+    }
     readback.unmap();
     saving = false;
   }


### PR DESCRIPTION
## Summary
- remove `@id` attributes from WGSL shaders for broader compatibility
- guard localStorage write against quota errors

## Testing
- `npx vitest run`
- `npx playwright test` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_688a40ad3f108323b741fb400cbc9689